### PR TITLE
Replace Prism with highlight.js

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,3 @@
-const pluginSyntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight')
-
 const md = require('./data/md')
 const setupBrowserSync = require('./eleventy/browserSync')
 const setupCollections = require('./eleventy/collections')
@@ -11,8 +9,6 @@ module.exports = (config) => {
   config.addPassthroughCopy({ './assets/favicon/': '/' })
   config.addPassthroughCopy({ './assets/fonts/': '/fonts/' })
   config.addPassthroughCopy('./content/**/*.{jpg,jpeg,png}')
-
-  config.addPlugin(pluginSyntaxHighlight, { alwaysWrapLineHighlights: true })
 
   // Defaults to true in Eleventy 1.0.
   // https://www.11ty.dev/docs/data-deep-merge/

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -82,14 +82,6 @@
     @apply bg-blue-400 bg-opacity-25;
     text-decoration-color: inherit; /* Chrome */
   }
-  pre code::selection,
-  pre code br::selection,
-  pre code del::selection,
-  pre code ins::selection,
-  pre code mark::selection,
-  pre code span::selection {
-    @apply bg-gray-700;
-  }
 
   *:focus {
     /* `outline: 0;` would make the focus ring invisible in Windows's
@@ -185,9 +177,6 @@
   .prose > * {
     max-width: 65ch;
   }
-  .prose > pre {
-    @apply max-w-none;
-  }
 
   .prose h1 code {
     @apply leading-tight;
@@ -282,65 +271,90 @@
     text-decoration-color: theme('colors.red.600');
   }
 
-  pre {
-    @apply -mx-6 sm:mx-0 sm:rounded-md;
-  }
-  pre code {
-    @apply inline-block min-w-full;
+  /*!
+    highlight.js theme: GitHub
+    Author: github.com
+    Maintainer: @Hirse
+
+    Slightly modified by me
+  */
+  .hljs {
+    color: #24292e;
   }
 
-  /* Syntax highlighting colors borrowed from https://blog.tailwindcss.com. See:
-   * - https://github.com/tailwindlabs/blog.tailwindcss.com/blob/39d37c/next.config.js#L8-L20
-   * - https://github.com/tailwindlabs/blog.tailwindcss.com/blob/39d37c/tailwind.config.js#L42-L51
-   */
-  .token.boolean,
-  .token.deleted,
-  .token.tag {
-    color: #ff8383; /* red */
+  .hljs-doctag,
+  .hljs-keyword,
+  .hljs-meta .hljs-keyword,
+  .hljs-template-tag,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable.language_ {
+    color: #d73a49;
   }
-  .token.attr-name,
-  .token.selector {
-    color: #ffe484; /* yellow */
+
+  .hljs-title,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-title.function_ {
+    color: #6f42c1;
   }
-  .token.attr-value,
-  .token.inserted,
-  .token.string,
-  .token.url {
-    color: #b5f4a5; /* green */
+
+  .hljs-attr,
+  .hljs-attribute,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-operator,
+  .hljs-variable,
+  .hljs-selector-attr,
+  .hljs-selector-class,
+  .hljs-selector-id {
+    color: #005cc5;
   }
-  .token.punctuation {
-    @apply text-white;
+
+  .hljs-regexp,
+  .hljs-string,
+  .hljs-meta .hljs-string {
+    color: #032f62;
   }
-  .token.keyword,
-  .token.property {
-    color: #d9a9ff; /* purple */
+
+  .hljs-built_in,
+  .hljs-symbol {
+    color: #e36209;
   }
-  .token.function {
-    color: #93ddfd; /* blue */
+
+  .hljs-comment,
+  .hljs-code,
+  .hljs-formula {
+    color: #6a737d;
   }
-  .token.comment {
+
+  .hljs-name,
+  .hljs-quote,
+  .hljs-selector-tag,
+  .hljs-selector-pseudo {
+    color: #22863a;
+  }
+
+  .hljs-subst {
+    color: #24292e;
+  }
+
+  .hljs-section {
+    @apply font-bold;
+    color: #005cc5;
+  }
+
+  .hljs-bullet {
+    color: #735c0f;
+  }
+
+  .hljs-emphasis,
+  .hljs-comment {
     @apply italic;
-    color: #9fa6b2; /* gray */
   }
 
-  .highlight-line {
-    @apply inline-block min-w-full px-4 xl:px-5;
-
-    /* `<del>`, `<ins>`, `<mark>` default styles */
-    @apply no-underline;
-    color: inherit;
-  }
-  .highlight-line:empty::before {
-    /* Enable highlighting empty lines */
-    content: ' ';
-  }
-  .highlight-line-active {
-    @apply bg-gray-700;
-  }
-  .highlight-line-add {
-    @apply bg-green-900;
-  }
-  .highlight-line-remove {
-    @apply bg-red-900;
+  .hljs-strong {
+    @apply font-bold;
   }
 }

--- a/components/CodeBlock.js
+++ b/components/CodeBlock.js
@@ -1,0 +1,123 @@
+const hljs = require('highlight.js')
+const { html } = require('htm/preact')
+
+const entity = require('../data/entity')
+
+module.exports = ({ attrs, code, lang }) => {
+  let highlightedCode
+
+  if (lang && hljs.getLanguage(lang)) {
+    try {
+      highlightedCode = hljs.highlight(code, { language: lang }).value
+    } catch {
+      console.error(`⚠ Error highlighting ${lang} code:\n${code}`)
+    }
+  } else {
+    console.error(`⚠ Unsupported code highlighting language: ${lang}`)
+  }
+
+  return html`
+    <!--
+      Needed by markdown-it;
+      if this doesn't start with '<pre',
+      markdown-it will wrap the return value in its own <pre> tag 🙄
+    -->
+    <pre class="hidden"></pre>
+
+    <div
+      class="bg-gray-100 border-t border-b max-w-none -mx-6 my-4 relative sm:border sm:mx-0 sm:rounded-md"
+    >
+      <${LineHighlights} lines=${getLineHighlights(attrs)} />
+
+      <!-- Hack: Prettier would misbehave with a regular '<pre' -->
+      <${'pre'} class="hljs px-6 py-4 relative sm:px-5">
+        <code
+          class="inline-block min-w-full"
+          dangerouslySetInnerHTML=${highlightedCode && {
+            __html: highlightedCode,
+          }}
+        >
+          ${!highlightedCode && code}
+        </code>
+      <//>
+    </div>
+  `
+}
+
+// Inspiration: https://github.com/11ty/eleventy-plugin-syntaxhighlight/issues/42
+function LineHighlights({ lines }) {
+  if (lines.length === 0) {
+    return null
+  }
+
+  return html`
+    <!-- TODO: Replace the style attr with something better -->
+    <div
+      aria-hidden="true"
+      class="absolute pt-4 select-none w-full"
+      style="font-size: 0.8888889em; line-height: 1.75"
+    >
+      ${lines.map((isHighlighted) =>
+        isHighlighted
+          ? html`<div class="bg-gray-200 w-full">${entity.nbsp}</div>`
+          : html`<br />`
+      )}
+    </div>
+  `
+}
+
+/**
+ * @param {string} attributes
+ * The attributes of a Markdown code block,
+ * i.e. whatever comes after ` ```lang `.
+ *
+ * @returns {boolean[]}
+ * An array of booleans
+ * where `true` means a highlighted line
+ * and `false` means a regular line.
+ * The length of the array
+ * equals to the line number of the last highlighted line.
+ *
+ * @example
+ * getLineHighlights('')
+ * //=> []
+ *
+ * @example
+ * getLineHighlights('3')
+ * //=> [false, false, true]
+ *
+ * @example
+ * getLineHighlights('2,5-7,9')
+ * //=> [false, true, false, false, true, true, true, false, true]
+ */
+function getLineHighlights(attributes) {
+  const maxLineNumber = attributes.match(/(\d+)$/)?.[0]
+
+  const highlightedLines = attributes.split(',').flatMap((lineNumbers) => {
+    const [from, to] = lineNumbers.split('-').map(Number)
+    return to ? range(from, to) : from
+  })
+
+  return range(1, maxLineNumber).reduce((lines, lineNumber) => {
+    lines.push(highlightedLines.includes(lineNumber))
+    return lines
+  }, [])
+}
+
+/**
+ * @param {number} from
+ * Start number, inclusive.
+ *
+ * @param {number} to
+ * End number, inclusive.
+ *
+ * @returns {number[]}
+ * An array of integers.
+ *
+ * @example
+ * range(5, 8)
+ * //=> [5, 6, 7, 8]
+ */
+function range(from, to) {
+  return Array.from({ length: to - from + 1 }, (_, i) => i + from)
+}

--- a/components/CodeBlock.js
+++ b/components/CodeBlock.js
@@ -29,7 +29,7 @@ module.exports = ({ attrs, code, lang }) => {
     >
       <${LineHighlights} lines=${getLineHighlights(attrs)} />
 
-      <!-- Hack: Prettier would misbehave with a regular '<pre' -->
+      <!-- Prettier would mess up the indentation with a regular '<pre' -->
       <${'pre'} class="hljs px-6 py-4 relative sm:px-5">
         <code
           class="inline-block min-w-full"
@@ -51,7 +51,10 @@ function LineHighlights({ lines }) {
   }
 
   return html`
-    <!-- TODO: Replace the style attr with something better -->
+    <!--
+      TODO: Replace the style attr with something better.
+      The values are from the '@tailwindcss/typography' plugin.
+    -->
     <div
       aria-hidden="true"
       class="absolute pt-4 select-none w-full"

--- a/data/entity.js
+++ b/data/entity.js
@@ -1,4 +1,5 @@
 const entity = {
+  nbsp: ' ', // non-breaking space
   ndash: '–',
 }
 

--- a/data/md.js
+++ b/data/md.js
@@ -1,13 +1,20 @@
+const { html } = require('htm/preact')
 const markdownIt = require('markdown-it')
 const markdownItAnchor = require('markdown-it-anchor')
 const markdownItAttrs = require('markdown-it-attrs')
 const markdownItDeflist = require('markdown-it-deflist')
 const markdownItFootnote = require('markdown-it-footnote')
 const markdownItLinkAttributes = require('markdown-it-link-attributes')
+const { render } = require('preact-render-to-string')
 
 const { slugify } = require('./slugify')
+const CodeBlock = require('../components/CodeBlock')
 
-const md = markdownIt({ html: true })
+const md = markdownIt({
+  highlight: (code, lang, attrs) =>
+    render(html`<${CodeBlock} attrs=${attrs} code=${code} lang=${lang} />`),
+  html: true,
+})
   .use(markdownItAnchor, {
     level: [2, 3],
     slugify,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,11 @@
     "": {
       "dependencies": {
         "@11ty/eleventy": "^0.12.1",
-        "@11ty/eleventy-plugin-syntaxhighlight": "git+https://github.com/mtsknn/eleventy-plugin-syntaxhighlight.git#53afb22",
         "@tailwindcss/typography": "^0.2.0",
         "cross-env": "^7.0.2",
         "date-fns": "^2.16.1",
+        "highlight.js": "^11.1.0",
+        "htm": "^3.1.0",
         "jsdom": "^16.4.0",
         "markdown-it": "^12.0.2",
         "markdown-it-anchor": "^8.1.2",
@@ -17,6 +18,8 @@
         "markdown-it-deflist": "^2.1.0",
         "markdown-it-footnote": "^3.0.2",
         "markdown-it-link-attributes": "^3.0.0",
+        "preact": "^10.5.14",
+        "preact-render-to-string": "^5.1.19",
         "slugify": "^1.4.6",
         "tailwindcss": "^1.9.6",
         "tailwindcss-important": "^1.0.0"
@@ -88,13 +91,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
-      }
-    },
-    "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
-      "resolved": "git+ssh://git@github.com/mtsknn/eleventy-plugin-syntaxhighlight.git#53afb224f67334a02c949591427b817167df16ad",
-      "dependencies": {
-        "jsdom": "^16.4.0",
-        "prismjs": "^1.21.0"
       }
     },
     "node_modules/@11ty/eleventy/node_modules/entities": {
@@ -994,17 +990,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "optional": true,
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -1405,12 +1390,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -2527,15 +2506,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
-      "dependencies": {
-        "delegate": "^3.1.2"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -2668,11 +2638,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.1.0.tgz",
+      "integrity": "sha512-X9VVhYKHQPPuwffO8jk4bP/FVj+ibNCy3HxZZNDXFtJrq4O5FdcdCDRIkDis5MiMnjh7UwEdHgRZJcHFYdzDdA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/htm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.0.tgz",
+      "integrity": "sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -4680,6 +4663,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/preact": {
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.14.tgz",
+      "integrity": "sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.1.19",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.1.19.tgz",
+      "integrity": "sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -4713,6 +4716,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
+    },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -4733,14 +4741,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "optionalDependencies": {
-        "clipboard": "^2.0.0"
       }
     },
     "node_modules/progress": {
@@ -5415,12 +5415,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
     },
     "node_modules/semver": {
       "version": "7.3.5",
@@ -6197,12 +6191,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
-    },
     "node_modules/to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
@@ -6821,14 +6809,6 @@
             "uc.micro": "^1.0.5"
           }
         }
-      }
-    },
-    "@11ty/eleventy-plugin-syntaxhighlight": {
-      "version": "git+ssh://git@github.com/mtsknn/eleventy-plugin-syntaxhighlight.git#53afb224f67334a02c949591427b817167df16ad",
-      "from": "@11ty/eleventy-plugin-syntaxhighlight@git+https://github.com/mtsknn/eleventy-plugin-syntaxhighlight.git#53afb22",
-      "requires": {
-        "jsdom": "^16.4.0",
-        "prismjs": "^1.21.0"
       }
     },
     "@babel/code-frame": {
@@ -7538,17 +7518,6 @@
         "readdirp": "~3.6.0"
       }
     },
-    "clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -7879,12 +7848,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -8793,15 +8756,6 @@
         }
       }
     },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -8901,11 +8855,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
+    "highlight.js": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.1.0.tgz",
+      "integrity": "sha512-X9VVhYKHQPPuwffO8jk4bP/FVj+ibNCy3HxZZNDXFtJrq4O5FdcdCDRIkDis5MiMnjh7UwEdHgRZJcHFYdzDdA=="
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "htm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.0.tgz",
+      "integrity": "sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -10465,6 +10429,19 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
+    "preact": {
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.14.tgz",
+      "integrity": "sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ=="
+    },
+    "preact-render-to-string": {
+      "version": "5.1.19",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.1.19.tgz",
+      "integrity": "sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==",
+      "requires": {
+        "pretty-format": "^3.8.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -10486,6 +10463,11 @@
         "js-beautify": "^1.6.12"
       }
     },
+    "pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U="
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -10497,14 +10479,6 @@
       "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
       "requires": {
         "parse-ms": "^0.1.0"
-      }
-    },
-    "prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "requires": {
-        "clipboard": "^2.0.0"
       }
     },
     "progress": {
@@ -11055,12 +11029,6 @@
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
       }
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
     },
     "semver": {
       "version": "7.3.5",
@@ -11715,12 +11683,6 @@
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
         }
       }
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
     },
     "to-array": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   },
   "dependencies": {
     "@11ty/eleventy": "^0.12.1",
-    "@11ty/eleventy-plugin-syntaxhighlight": "git+https://github.com/mtsknn/eleventy-plugin-syntaxhighlight.git#53afb22",
     "@tailwindcss/typography": "^0.2.0",
     "cross-env": "^7.0.2",
     "date-fns": "^2.16.1",
+    "highlight.js": "^11.1.0",
+    "htm": "^3.1.0",
     "jsdom": "^16.4.0",
     "markdown-it": "^12.0.2",
     "markdown-it-anchor": "^8.1.2",
@@ -24,6 +25,8 @@
     "markdown-it-deflist": "^2.1.0",
     "markdown-it-footnote": "^3.0.2",
     "markdown-it-link-attributes": "^3.0.0",
+    "preact": "^10.5.14",
+    "preact-render-to-string": "^5.1.19",
     "slugify": "^1.4.6",
     "tailwindcss": "^1.9.6",
     "tailwindcss-important": "^1.0.0"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -137,14 +137,15 @@ module.exports = {
             content: null,
           },
           pre: {
-            color: theme('colors.gray.100'), // The default is 300 but too dark
-            backgroundColor: theme('colors.gray.800'),
+            color: null,
+            backgroundColor: null,
             borderRadius: null,
-
-            // Remove horizontal padding; it's added for each line
-            // (`span.highligh-line`) in `main.css`
-            paddingLeft: null,
+            marginTop: null,
+            marginBottom: null,
+            paddingTop: null,
             paddingRight: null,
+            paddingBottom: null,
+            paddingLeft: null,
           },
           'pre code': {
             whiteSpace: 'pre',
@@ -168,8 +169,12 @@ module.exports = {
         css: {
           pre: {
             borderRadius: null,
-            paddingLeft: null,
+            marginTop: null,
+            marginBottom: null,
+            paddingTop: null,
             paddingRight: null,
+            paddingBottom: null,
+            paddingLeft: null,
           },
         },
       },
@@ -177,8 +182,12 @@ module.exports = {
         css: {
           pre: {
             borderRadius: null,
-            paddingLeft: null,
+            marginTop: null,
+            marginBottom: null,
+            paddingTop: null,
             paddingRight: null,
+            paddingBottom: null,
+            paddingLeft: null,
           },
         },
       },
@@ -186,8 +195,12 @@ module.exports = {
         css: {
           pre: {
             borderRadius: null,
-            paddingLeft: null,
+            marginTop: null,
+            marginBottom: null,
+            paddingTop: null,
             paddingRight: null,
+            paddingBottom: null,
+            paddingLeft: null,
           },
         },
       },
@@ -195,8 +208,12 @@ module.exports = {
         css: {
           pre: {
             borderRadius: null,
-            paddingLeft: null,
+            marginTop: null,
+            marginBottom: null,
+            paddingTop: null,
             paddingRight: null,
+            paddingBottom: null,
+            paddingLeft: null,
           },
         },
       },


### PR DESCRIPTION
Also changed code block styles from dark to light. A dark theme would better suit a site-wide dark theme which I'm planning to implement some day.

Pros:

- Indentation of code blocks works now properly. The 11ty plugin sometimes messes up indentation; see the screenshot at the end.
- Moved some styles from the ugly `main.css` to the new `CodeBlock.js`.
- Line highlights are now specified with a syntax that's more compatible with Prettier.
  - Before: ` ```js/2,4-7,10 `
    - 0-based
    - Prettier doesn't recognize the lang `js/2,4-7,10`, so it doesn't format the code block
  - After: ` ```js 3,5-8,11 `
    - 1-based (IMO clearer)
    - Prettier recognizes the lang `js` just fine
- 1 dependency less (the 11ty plugin). I had forked it before (see commit 423d059) but never updated it to match upstream, and now I don't have to!
- Now that I'm handling line highlights myself (instead of the 11ty plugin doing it), I have means to implement other things as well:
  - More granular highlighting
    - [Inspiration](https://thepaciellogroup.github.io/cupper/patterns/coding/code-blocks/#annotated-code) 😍
  - Copy button
  - Metadata, e.g. show the language ("JavaScript") and a file name ("foo.js")
- The build logs mention if I have code blocks with unsupported languages, or if highlighting some code fails for some reason.

Cons:

- Pug is not supported by highlight.js, though I have only one such code block anyway.
- More own code to maintain, but that's okay because my own code is good code. 😜

Preact might seem like an overkill, but I'm planning to later replace Pug layouts with Preact layouts, so installing Preact and related libraries was inevitable. :thanos:

Btw I noticed that code block styles inside lists/quotes/etc. are broken in XS screen size. But they were broken even before this PR, so I'm going to fix them later (yeah, right 😅).

---

Screenshot from [my latest blog post](https://mtsknn.fi/blog/how-to-render-optimizely-content-recommendations-using-react/) showing the indentation bug in the 11ty plugin:

![](https://user-images.githubusercontent.com/2226144/127694850-3dc96ab6-b5a5-4eb7-955c-bc0917cb5cbc.png)

I have previously circumvented this by adding extra leading spaces to those broken lines and added `<!-- prettier-ignore -->` before the code block so that Prettier won't remove the extra spaces when saving the Markdown file. Then the code block looks correct on my blog, but has the unnecessary extra spaces when copy-pasting the code elsewhere. Not always a problem, but is an actual problem when copy-pasting e.g. YAML code (which is whitespace-sensitive). 😬 Plus these workarounds are a hassle to maintain.