### PR TITLE
Slugify forward slashes to dashes

### DIFF
--- a/data/slugify.js
+++ b/data/slugify.js
@@ -2,6 +2,7 @@ const slugify = require('slugify')
 
 const mySlugify = (text = '') => {
   return [text]
+    .map((x) => x.replace(/\//g, '-'))
     .map((x) => x.replace(/c#/gi, 'csharp'))
     .map((x) => x.replace(/\.NET/g, 'dotnet'))
     .map((x) => slugify(x, { lower: true, strict: true }))[0]

--- a/data/slugify.js
+++ b/data/slugify.js
@@ -3,7 +3,7 @@ const slugify = require('slugify')
 const mySlugify = (text = '') => {
   return [text]
     .map((x) => x.replace(/\//g, '-'))
-    .map((x) => x.replace(/c#/gi, 'csharp'))
+    .map((x) => x.replace(/C#/g, 'csharp'))
     .map((x) => x.replace(/\.NET/g, 'dotnet'))
     .map((x) => slugify(x, { lower: true, strict: true }))[0]
 }


### PR DESCRIPTION
Makes URL slugs look better. E.g.:

- "C#/.NET": `csharpdotnet` → `csharp-dotnet`
- "remainder/modulo operator": `remaindermodulo-operator` → `remainder-modulo-operator`

Only two anchor links of level 2 or 3 headings change, so no big deal to make this change now.

Also change slugify to handle only uppercase "C#"; not sure when I would write "c#" in lowercase.