### PR TITLE
Improve code blocks

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -182,13 +182,18 @@
     @apply leading-tight;
   }
 
-  .prose .list-none::before {
-    content: none;
+  .prose .link-external code,
+  .prose li > code {
+    @apply inline py-px;
   }
 
-  .prose .link-external code,
-  .prose li code {
-    @apply inline py-px;
+  .prose blockquote pre,
+  .prose li pre {
+    @apply border mx-0 rounded-md;
+  }
+
+  .prose .list-none::before {
+    content: none;
   }
 
   .prose dl {
@@ -271,110 +276,147 @@
     text-decoration-color: theme('colors.red.600');
   }
 
-  /*
-    highlight.js theme: GitHub
-    Author: github.com
-    Maintainer: @Hirse
-
-    Slightly modified by me
-  */
-  .hljs {
-    color: #24292e;
+  /**
+   * GHColors theme for Prism by Avi Aryan (https://aviaryan.in/)
+   * Inspired by GitHub syntax coloring
+   *
+   * Slightly modified by me (Matias)
+   */
+  pre[class*='language-'] {
+    color: #393a34;
   }
 
-  .hljs-doctag,
-  .hljs-keyword,
-  .hljs-meta .hljs-keyword,
-  .hljs-template-tag,
-  .hljs-template-variable,
-  .hljs-type,
-  .hljs-variable.language_ {
-    color: #d73a49;
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #999988;
+    font-style: italic;
   }
 
-  .hljs-title,
-  .hljs-title.class_,
-  .hljs-title.class_.inherited__,
-  .hljs-title.function_ {
-    color: #6f42c1;
+  .token.namespace {
+    opacity: 0.75;
   }
 
-  .hljs-attr,
-  .hljs-attribute,
-  .hljs-literal,
-  .hljs-meta,
-  .hljs-number,
-  .hljs-operator,
-  .hljs-variable,
-  .hljs-selector-attr,
-  .hljs-selector-class,
-  .hljs-selector-id {
-    color: #005cc5;
+  .token.string,
+  .token.attr-value {
+    color: #e3116c;
   }
 
-  .hljs-regexp,
-  .hljs-string,
-  .hljs-meta .hljs-string {
-    color: #032f62;
+  .token.punctuation,
+  .token.operator {
+    color: #393a34;
   }
 
-  .hljs-built_in,
-  .hljs-symbol {
-    color: #e36209;
+  .token.entity,
+  .token.url,
+  .token.symbol,
+  .token.number,
+  .token.boolean,
+  .token.variable,
+  .token.constant,
+  .token.property,
+  .token.regex,
+  .token.inserted {
+    color: #36acaa;
   }
 
-  .hljs-comment,
-  .hljs-code,
-  .hljs-formula {
-    color: #6a737d;
+  .token.atrule,
+  .token.keyword,
+  .token.attr-name {
+    color: #00a4db;
   }
 
-  .hljs-name,
-  .hljs-quote,
-  .hljs-selector-tag,
-  .hljs-selector-pseudo {
-    color: #22863a;
+  .token.function,
+  .token.deleted {
+    color: #9a050f;
   }
 
-  .hljs-subst {
-    color: #24292e;
+  .token.tag,
+  .token.selector {
+    color: #00009f;
   }
 
-  .hljs-section {
-    @apply font-bold;
-    color: #005cc5;
+  .token.important,
+  .token.bold {
+    font-weight: bold;
   }
 
-  .hljs-bullet {
-    color: #735c0f;
+  .token.italic {
+    font-style: italic;
+  }
+  /* End of theme */
+
+  pre[class*='language-'] {
+    /* Needed by iOS Safari or some lines might wrap */
+    word-wrap: normal;
   }
 
-  .hljs-emphasis,
-  .hljs-comment {
-    @apply italic;
-  }
-
-  .hljs-strong {
-    @apply font-bold;
-  }
-  /* End of the GitHub highlight.js theme */
-
-  .hljs-addition,
-  .hljs-deletion {
-    @apply inline-block -ml-6 pl-6 sm:-ml-5 sm:pl-5;
+  .actual-code {
     width: calc(100% + 2 * theme('margin.6'));
   }
-  .hljs-addition {
-    @apply bg-green-200 text-green-800;
-  }
-  .hljs-deletion {
-    @apply bg-red-200 text-red-800;
+  @screen sm {
+    .actual-code {
+      width: calc(100% + 2 * theme('margin.5'));
+    }
   }
 
+  pre[class*='language-'] .token {
+    /* Without this, line highlights would be over the actual code */
+    @apply relative;
+  }
+
+  .token.prefix.inserted {
+    color: #008000;
+  }
+  .token.prefix.deleted {
+    color: #d91e18;
+  }
+
+  .token.inserted-sign,
+  .token.deleted-sign {
+    @apply flow-root -ml-6 pl-6 sm:-ml-5 sm:pl-5;
+    width: calc(100% + theme('margin.6'));
+  }
   @screen sm {
-    .hljs-addition,
-    .hljs-deletion {
-      width: calc(100% + 2 * theme('margin.5'));
+    .token.inserted-sign,
+    .token.deleted-sign {
+      width: calc(100% + theme('margin.5'));
+    }
+  }
+
+  .token.inserted-sign {
+    background: linear-gradient(
+      to right,
+      theme('colors.green.300'),
+      theme('colors.green.300') theme('borderWidth.6'),
+      theme('colors.green.100') theme('borderWidth.6')
+    );
+  }
+  .token.deleted-sign {
+    background: linear-gradient(
+      to right,
+      theme('colors.red.300'),
+      theme('colors.red.300') theme('borderWidth.6'),
+      theme('colors.red.100') theme('borderWidth.6')
+    );
+  }
+  @screen sm {
+    .token.inserted-sign {
+      background: linear-gradient(
+        to right,
+        theme('colors.green.300'),
+        theme('colors.green.300') theme('borderWidth.4'),
+        theme('colors.green.100') theme('borderWidth.4')
+      );
+    }
+    .token.deleted-sign {
+      background: linear-gradient(
+        to right,
+        theme('colors.red.300'),
+        theme('colors.red.300') theme('borderWidth.4'),
+        theme('colors.red.100') theme('borderWidth.4')
+      );
     }
   }
 }

--- a/components/CodeBlock.js
+++ b/components/CodeBlock.js
@@ -9,8 +9,20 @@ setupPrism()
 module.exports = ({ attrs, code, lang }) => {
   return html`
     <!-- Prettier would mess up the indentation with a regular '<pre' -->
+    <!--
+      'aria-label', 'role' and 'tabindex'
+      for keyboard accessibility. 👍
+      See https://marcus.io/blog/accessible-overflow
+
+      Not sure if it's a good idea
+      to duplicate the 'aria-label'
+      across all code blocks on a page...
+    -->
     <${'pre'}
+      aria-label="Code block"
       class="language-${lang} bg-white border-t border-b max-w-none -mx-6 my-4 relative sm:border sm:mx-0 sm:rounded-md"
+      role="region"
+      tabindex="0"
     >
       <code class="min-w-full !px-6 py-4 relative sm:!px-5">
         <${LineHighlights} lines=${getLineHighlights(attrs)} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
         "@tailwindcss/typography": "^0.2.0",
         "cross-env": "^7.0.2",
         "date-fns": "^2.16.1",
-        "highlight.js": "^11.1.0",
         "htm": "^3.1.0",
         "markdown-it": "^12.0.2",
         "markdown-it-anchor": "^8.1.2",
@@ -19,6 +18,7 @@
         "markdown-it-link-attributes": "^3.0.0",
         "preact": "^10.5.14",
         "preact-render-to-string": "^5.1.19",
+        "prismjs": "^1.24.1",
         "slugify": "^1.4.6",
         "tailwindcss": "^1.9.6",
         "tailwindcss-important": "^1.0.0"
@@ -2404,14 +2404,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.1.0.tgz",
-      "integrity": "sha512-X9VVhYKHQPPuwffO8jk4bP/FVj+ibNCy3HxZZNDXFtJrq4O5FdcdCDRIkDis5MiMnjh7UwEdHgRZJcHFYdzDdA==",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -4323,6 +4315,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/prismjs": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
+      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -7972,11 +7969,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
-    "highlight.js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.1.0.tgz",
-      "integrity": "sha512-X9VVhYKHQPPuwffO8jk4bP/FVj+ibNCy3HxZZNDXFtJrq4O5FdcdCDRIkDis5MiMnjh7UwEdHgRZJcHFYdzDdA=="
-    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -9438,6 +9430,11 @@
       "requires": {
         "parse-ms": "^0.1.0"
       }
+    },
+    "prismjs": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
+      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@tailwindcss/typography": "^0.2.0",
     "cross-env": "^7.0.2",
     "date-fns": "^2.16.1",
-    "highlight.js": "^11.1.0",
     "htm": "^3.1.0",
     "markdown-it": "^12.0.2",
     "markdown-it-anchor": "^8.1.2",
@@ -26,6 +25,7 @@
     "markdown-it-link-attributes": "^3.0.0",
     "preact": "^10.5.14",
     "preact-render-to-string": "^5.1.19",
+    "prismjs": "^1.24.1",
     "slugify": "^1.4.6",
     "tailwindcss": "^1.9.6",
     "tailwindcss-important": "^1.0.0"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,9 @@ module.exports = {
       position: ['bottom', 'right'],
     },
     extend: {
+      borderWidth: {
+        6: '6px',
+      },
       colors: {
         // `cool-gray` colors borrowed from `@tailwindcss/ui`. These seem to be
         // better from accessibility perspective (easier to get high enough
@@ -121,14 +124,13 @@ module.exports = {
             color: theme('colors.gray.900'),
             fontWeight: null,
 
-            backgroundColor: theme('colors.gray.100'),
+            backgroundColor: theme('colors.white'),
             borderRadius: theme('borderRadius.lg'),
             display: 'inline-block',
             lineHeight: theme('lineHeight.relaxed'),
             paddingLeft: theme('padding.1'),
             paddingRight: theme('padding.1'),
             borderWidth: theme('borderWidth.default'),
-            borderColor: theme('colors.gray.400'),
           },
           'code::before': {
             content: null,
@@ -148,6 +150,7 @@ module.exports = {
             paddingLeft: null,
           },
           'pre code': {
+            padding: null,
             whiteSpace: 'pre',
           },
           'pre code::before': {


### PR DESCRIPTION
- Replace highlight.js with Prism
  - I replaced Prism with highlight.js less than 3 weeks ago in #11 😅 but [Prism's Diff Highlight plugin](https://prismjs.com/plugins/diff-highlight/) makes `diff` code blocks look much better!
- Update styles
  - Before (third line highlighted for demo purposes only):
    ![Styles before the PR: darker colors, stuffy.](https://user-images.githubusercontent.com/2226144/129841620-e784b3c8-d5c8-4e3b-826c-bc2a7b61465e.png)
  - After:
    ![Styles after the PR: lighter colors, line highlight markers at the beginning of lines.](https://user-images.githubusercontent.com/2226144/129841697-9647a815-6a5c-44e3-afdc-f88036e0901f.png)
- Fix visual bugs
  - Addition/deletion lines in `diff` code blocks had extra space below them on iOS Safari (Telegram converted the screenshot to JPG 🤦‍♂️):
    ![iOS Safari bug: extra space below highlighted lines in diff code blocks.](https://user-images.githubusercontent.com/2226144/129843644-638e1785-e4f0-4c50-bb02-3a743986207d.jpg)
  - Long lines sometimes wrapped on iOS Safari:
    ![iOS Safari bug: a long line wrapping.](https://user-images.githubusercontent.com/2226144/129843664-aeaaaa4f-7a84-4b17-a6b3-15230a0d8ca8.jpg)
  - Identation of code blocks was off inside lists and blockquotes in XS screen size:
    ![Bug in XS screen size: indentation of code blocks inside lists were off.](https://user-images.githubusercontent.com/2226144/129843698-a353dbcb-209e-4b21-b0ad-bf54fd6c5f1e.png)
- Make code blocks focusable for keyboard accessibility
  - Hat tip to Jake Trent for inspiring me originally with his article [_Make Code Blocks Keyboard Accessible_](https://jaketrent.com/post/make-code-blocks-keyboard-accessibility)
  - Hat tip to Andria Brown for reminding me of the issue with her [PR #48 to eleventy-plugin-syntaxhighlight](https://github.com/11ty/eleventy-plugin-syntaxhighlight/pull/48)
  - Hat tip to Marcus Herrmann for his article [_Accessible Overflow_](https://marcus.io/blog/accessible-overflow). Otherwise I would have added only `tabindex="0"`, not `aria-label` and `role="region"`