### PR TITLE
Remove focus outline from mouse-selected code blocks

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -92,6 +92,10 @@
     box-decoration-break: clone;
   }
 
+  pre:not(:focus-visible) {
+    @apply shadow-none;
+  }
+
   h2,
   h3,
   h4 {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -365,11 +365,6 @@
     }
   }
 
-  pre[class*='language-'] .token {
-    /* Without this, line highlights would be over the actual code */
-    @apply relative;
-  }
-
   .token.prefix.inserted {
     color: #008000;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -875,9 +875,13 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001154",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz",
-      "integrity": "sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org=="
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.1",
@@ -6724,9 +6728,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001154",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz",
-      "integrity": "sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org=="
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A=="
     },
     "chalk": {
       "version": "4.1.1",


### PR DESCRIPTION
Code blocks are keyboard-focusable as of #16, but the focus outline is unnecessary and ugly when clicking on a code block with the mouse. Thanks to @Steellow for the heads-up. 😎

Also:

- Remove obsolete styles
- Update `caniuse-lite`