### PR TITLE
Remove obsolete URL redirection

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -150,11 +150,6 @@
   status = 301
 
 [[redirects]]
-  from = "/cookbook/npm-list-globally-installed-packages/"
-  to   = "/blog/how-to-list-globally-installed-npm-packages/"
-  status = 301
-
-[[redirects]]
   from = "/cookbook/npm-sort-package-json/"
   to   = "/blog/how-to-sort-package-json-automatically/"
   status = 301


### PR DESCRIPTION
The blog post in question was too simple so I removed it. (In npm v7+, `npm ls -g` just works, but in earlier versions you also had to use the `--depth=0` flag.)