### PR TITLE
Improve usage of Plausible Analytics

### DIFF
--- a/_sample-content/404.md
+++ b/_sample-content/404.md
@@ -17,6 +17,7 @@ permalink: 404.html
 <!-- Uncomment if you use Plausible Analytics (https://plausible.io/docs/404-error-pages-tracking) -->
 <!--
 <script>
+  window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
   plausible('404', { props: { path: document.location.pathname } })
 </script>
 -->

--- a/_sample-content/404.md
+++ b/_sample-content/404.md
@@ -13,3 +13,10 @@ permalink: 404.html
 # {{ title }}
 
 [Go home!](/)
+
+<!-- Uncomment if you use Plausible Analytics (https://plausible.io/docs/404-error-pages-tracking) -->
+<!--
+<script>
+  plausible('404', { props: { path: document.location.pathname } })
+</script>
+-->

--- a/data/utils.js
+++ b/data/utils.js
@@ -36,6 +36,19 @@ const utils = {
         return found
       }),
   isDraft: (data) => data.page.filePathStem.includes('/drafts/'),
+
+  /**
+   * Checks whether the current Netlify deploy context is `production`.
+   *
+   * Other possible contexts are `deploy-preview` and `branch-deploy`,
+   * so returns `false` in deploy previews ("PR previews") and branch deploys.
+   *
+   * Returns `false` in non-Netlify environments, e.g. localhost.
+   *
+   * @see <https://docs.netlify.com/configure-builds/environment-variables/#build-metadata>
+   */
+  isNetlifyProductionContext: () => process.env.CONTEXT === 'production',
+
   isProductionEnv: process.env.NODE_ENV === 'production',
   isScheduled: (data) => data.date >= now,
 }

--- a/layouts/_layout.pug
+++ b/layouts/_layout.pug
@@ -83,7 +83,7 @@ html(lang="en")
       async
       data-domain="mtsknn.fi"
       defer
-      src="https://mtsknn.fi/elbisualp/js/script.js"
+      src="/elbisualp/js/script.js"
     )
   body#top.bg-gray-50.break-words.font-sans(
     class={ 'debug-screens': process.env.NODE_ENV === 'development' }

--- a/layouts/_layout.pug
+++ b/layouts/_layout.pug
@@ -83,7 +83,7 @@ html(lang="en")
       async
       data-domain="mtsknn.fi"
       defer
-      src="https://stats.mtsknn.fi/js/plausible.outbound-links.js"
+      src="https://mtsknn.fi/elbisualp/js/script.js"
     )
   body#top.bg-gray-50.break-words.font-sans(
     class={ 'debug-screens': process.env.NODE_ENV === 'development' }

--- a/layouts/_layout.pug
+++ b/layouts/_layout.pug
@@ -80,7 +80,6 @@ html(lang="en")
     )
 
     script(
-      async
       data-api="/elbisualp/api/event"
       data-domain="mtsknn.fi"
       defer

--- a/layouts/_layout.pug
+++ b/layouts/_layout.pug
@@ -79,12 +79,13 @@ html(lang="en")
       title=`${site.title} ${entity.ndash} Weekly log (JSON)`
     )
 
-    script(
-      data-api="/elbisualp/api/event"
-      data-domain="mtsknn.fi"
-      defer
-      src="/elbisualp/js/script.js"
-    )
+    if utils.isNetlifyProductionContext()
+      script(
+        data-api="/elbisualp/api/event"
+        data-domain="mtsknn.fi"
+        defer
+        src="/elbisualp/js/script.js"
+      )
   body#top.bg-gray-50.break-words.font-sans(
     class={ 'debug-screens': process.env.NODE_ENV === 'development' }
   )

--- a/layouts/_layout.pug
+++ b/layouts/_layout.pug
@@ -81,6 +81,7 @@ html(lang="en")
 
     script(
       async
+      data-api="/elbisualp/api/event"
       data-domain="mtsknn.fi"
       defer
       src="/elbisualp/js/script.js"

--- a/layouts/_layout.pug
+++ b/layouts/_layout.pug
@@ -85,14 +85,6 @@ html(lang="en")
       defer
       src="https://stats.mtsknn.fi/js/plausible.outbound-links.js"
     )
-
-    //- Needed for tracking custom events like 404 pages
-    script.
-      window.plausible =
-        window.plausible ||
-        function () {
-          ;(window.plausible.q = window.plausible.q || []).push(arguments)
-        }
   body#top.bg-gray-50.break-words.font-sans(
     class={ 'debug-screens': process.env.NODE_ENV === 'development' }
   )

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,18 @@
     [headers.values]
       Cache-Control = "public, max-age=31536000"
 
+# Proxy for Plausible Analytics (https://plausible.io/docs/proxy/guides/netlify)
+
+[[redirects]]
+  from = "/elbisualp/js/script.js"
+  to   = "https://plausible.io/js/plausible.outbound-links.js"
+  status = 200
+
+[[redirects]]
+  from = "/elbisualp/api/event"
+  to   = "https://plausible.io/api/event"
+  status = 202
+
 # Temporary redirects (302)
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,16 +16,16 @@
     [headers.values]
       Cache-Control = "public, max-age=31536000"
 
-# Proxy for Plausible Analytics (https://plausible.io/docs/proxy/guides/netlify)
+# Proxy for Plausible Analytics: https://plausible.io/docs/proxy/guides/netlify
 
 [[redirects]]
-  from = "/elbisualp/js/script.js"
-  to   = "https://plausible.io/js/plausible.outbound-links.js"
+  from   = "/elbisualp/js/script.js"
+  to     = "https://plausible.io/js/plausible.outbound-links.js"
   status = 200
 
 [[redirects]]
-  from = "/elbisualp/api/event"
-  to   = "https://plausible.io/api/event"
+  from   = "/elbisualp/api/event"
+  to     = "https://plausible.io/api/event"
   status = 202
 
 # Temporary redirects (302)


### PR DESCRIPTION
- Switch from custom domain (stats.mtsknn.fi) to proxy URLs
  - [Custom domains are deprecated](https://plausible.io/docs/custom-domain/)
  - [Proxies are recommended instead](https://plausible.io/docs/proxy/introduction)
- Move 404-related JS code from `_layout.pug` to `404.md`
- Remove `async` from `<script>`
  - Now `defer` will be used, so HTML parsing won't be paused when the script has been loaded and is being executed (see [`async` vs `defer` on Stack Overflow](https://stackoverflow.com/q/10808109/1079869))
- Disable analytics in localhost and Netlify PR previews