### PR TITLE
Fix inline code spanning two lines in (iOS) Safari

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -120,6 +120,16 @@
     max-width: 65ch;
   }
 
+  .prose code {
+    /* Fix for Safari and iOS Safari:
+     * without this,
+     * inline code might span two lines
+     * even if it has plenty room on a single line.
+     * Screenshot: https://github.com/mtsknn/mtsknn.fi/pull/34
+     */
+    white-space: pre-wrap;
+  }
+
   .prose h1 code {
     @apply leading-tight;
   }


### PR DESCRIPTION
![Screenshot of a blog post title and intro with the bug visible in the intro.](https://user-images.githubusercontent.com/2226144/162879560-052bae2d-dfec-444e-913f-bd5789d5e665.png)

Screenshot from the [`git undo` post](https://mtsknn.fi/blog/how-to-undo-the-last-previous-most-recent-commit-in-git/). Have seen the bug in some other posts as well.