### PR TITLE
Render trailing spaces in inline codes spanning 2+ lines

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -132,6 +132,9 @@ module.exports = {
             paddingLeft: theme('padding.1'),
             paddingRight: theme('padding.1'),
             borderWidth: theme('borderWidth.default'),
+
+            // Render trailing spaces if the inline code spans 2+ lines
+            whiteSpace: 'pre-wrap',
           },
           'code::before': {
             content: null,


### PR DESCRIPTION
Before (from my [hyperscript post](https://mtsknn.fi/blog/hyperscript-hyperior-alternative-to-jsx/)):

![Screenshot before the changes.](https://user-images.githubusercontent.com/2226144/163924357-9740e4d1-6b33-46a3-a44f-2ba4f4398ab2.png)

After – notice the trailing spaces in the code blocks, but not after `href=`:

![Screenshot after the changes.](https://user-images.githubusercontent.com/2226144/163924365-4f2fda4e-b6b9-46bd-a26f-0cdb04d22490.png)