### PR TITLE
Support wildcard redirects in localhost

### DIFF
--- a/eleventy/browserSync.js
+++ b/eleventy/browserSync.js
@@ -20,7 +20,12 @@ module.exports = (config) => {
               status: Number(status) || 301,
             }))
 
-          const redirect = redirects.find(({ fromUrl }) => fromUrl === req.url)
+          const redirect = redirects.find(({ fromUrl }) =>
+            fromUrl.endsWith('*')
+              ? req.url.startsWith(fromUrl.slice(0, -1))
+              : fromUrl === req.url
+          )
+
           if (redirect) {
             res.writeHead(redirect.status, { location: redirect.toUrl })
             res.end()


### PR DESCRIPTION
Improves the local redirects code made in #47 by adding support for e.g. `/weekly-log/*` → [`/blog/bye-weekly-log/`](https://mtsknn.fi/blog/bye-weekly-log/).

Looks like there's also [Netlify Redirect Parser](https://github.com/netlify/build/tree/main/packages/redirect-parser) which would be more robust, but my quick implementation is good enough for me.